### PR TITLE
Fix: Correct pagination logic in GeSpecialtProperties

### DIFF
--- a/BrokerMVC.Tests/Controllers/HomeControllerTest.cs
+++ b/BrokerMVC.Tests/Controllers/HomeControllerTest.cs
@@ -6,6 +6,8 @@ using System.Web.Mvc;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using BrokerMVC;
 using BrokerMVC.Controllers;
+using BrokerMVC.Models;
+using BrokerMVC.Models.ViewModel;
 
 namespace BrokerMVC.Tests.Controllers
 {
@@ -49,6 +51,23 @@ namespace BrokerMVC.Tests.Controllers
 
             // Assert
             Assert.IsNotNull(result);
+        }
+
+        [TestMethod]
+        public void GeSpecialtProperties_ShouldReturnFirstPage_WhenPageIsNull()
+        {
+            // Arrange
+            HomeController controller = new HomeController();
+            int pageSize = 5;
+
+            // Act
+            PartialViewResult result = controller.GeSpecialtProperties(null, pageSize) as PartialViewResult;
+            var model = result.Model as HorizonatlPropertyListView;
+
+            // Assert
+            Assert.IsNotNull(result, "Result should not be null.");
+            Assert.IsNotNull(model, "Model should not be null.");
+            Assert.IsTrue(model.ReqularProperties.Count > 0, "The first page of properties should be returned, but the list is empty.");
         }
     }
 }

--- a/BrokerMVC/Controllers/HomeController.cs
+++ b/BrokerMVC/Controllers/HomeController.cs
@@ -49,22 +49,9 @@ namespace BrokerMVC.Controllers
             int pageNumber = (Page ?? 1);
             HorizonatlPropertyListView View = new HorizonatlPropertyListView();
             View.SpecailProperty = Repository.GetSpecailProperties().OrderByDescending(p => p.ChangeActiveStatus).FirstOrDefault();
-            if (pageNumber == 0)
-            {
-                View.ReqularProperties = Repository.GetSpecailProperties().OrderByDescending(p => p.ChangeActiveStatus).Take(PageSize).ToList();
-            }
-            else
-            {
-                var count = Repository.CountSpecailProperties();
-                if (count > (pageNumber * PageSize) + PageSize)
-                {
-                    View.ReqularProperties = Repository.GetSpecailProperties().OrderByDescending(p => p.ChangeActiveStatus).Skip((pageNumber * PageSize) + PageSize).Take(PageSize).ToList();
-                }
-                else
-                {
-                    View.ReqularProperties = new List<RealEstate>();
-                }
-            }
+
+            View.ReqularProperties = Repository.GetSpecailProperties().OrderByDescending(p => p.ChangeActiveStatus).Skip((pageNumber - 1) * PageSize).Take(PageSize).ToList();
+
             View.Name = General.SpecialPropList;
             return PartialView("Partial/SpecialProperties", View);
         }


### PR DESCRIPTION
The pagination logic in the `GeSpecialtProperties` method was flawed, causing incorrect or empty results to be returned. The `pageNumber` was not being handled correctly, and the `Skip` calculation was wrong.

This commit corrects the pagination by:
- Ensuring `pageNumber` defaults to 1.
- Using the standard `Skip((pageNumber - 1) * PageSize)` formula to correctly calculate the offset.

A new unit test has been added to verify that the first page is returned correctly when the `Page` parameter is null.