### PR TITLE
Fix: Correct pagination logic in GetPropertiesBySaleType

### DIFF
--- a/BrokerMVC.Tests/Controllers/HomeControllerTest.cs
+++ b/BrokerMVC.Tests/Controllers/HomeControllerTest.cs
@@ -69,5 +69,25 @@ namespace BrokerMVC.Tests.Controllers
             Assert.IsNotNull(model, "Model should not be null.");
             Assert.IsTrue(model.ReqularProperties.Count > 0, "The first page of properties should be returned, but the list is empty.");
         }
+
+        [TestMethod]
+        public void GetPropertiesBySaleType_ShouldReturnFirstPageOfResults()
+        {
+            // Arrange
+            var controller = new HomeController();
+            int saleTypeId = 1; // Assuming 1 is for Sale
+            int pageSize = 5;
+
+            // Act
+            var result = controller.GetPropertiesBySaleType(saleTypeId, 1, pageSize) as PartialViewResult;
+            var model = result.Model as HorizonatlPropertyListView;
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsNotNull(model);
+            // This assertion is expected to fail with the buggy code if there are fewer than 11 properties of the given sale type.
+            // The bug causes page 1 to skip 10 items. After the fix, it will skip 0 items and return the first page.
+            Assert.IsTrue(model.ReqularProperties.Count > 0, "The first page of properties should be returned, but the list is empty. This is likely due to the pagination bug skipping too many records.");
+        }
     }
 }

--- a/BrokerMVC/Controllers/HomeController.cs
+++ b/BrokerMVC/Controllers/HomeController.cs
@@ -61,14 +61,7 @@ namespace BrokerMVC.Controllers
             int pageNumber = (Page ?? 1);
             HorizonatlPropertyListView View = new HorizonatlPropertyListView();
             View.SpecailProperty = Repository.GetSpecailProperties().OrderByDescending(p => Guid.NewGuid()).FirstOrDefault();
-            if (pageNumber == 0)
-            {
-                View.ReqularProperties = Repository.GetPropertiesBySaleType(SaleTypeID).OrderByDescending(p => p.ChangeActiveStatus).Take(PageSize).ToList();
-            }
-            else
-            {
-                View.ReqularProperties = Repository.GetPropertiesBySaleType(SaleTypeID).OrderByDescending(p => p.ChangeActiveStatus).Skip((pageNumber * PageSize) + PageSize).Take(PageSize).ToList();
-            }
+            View.ReqularProperties = Repository.GetPropertiesBySaleType(SaleTypeID).OrderByDescending(p => p.ChangeActiveStatus).Skip((pageNumber - 1) * PageSize).Take(PageSize).ToList();
             if (SaleTypeID == (int)SaleTypes.Sale)
                 View.Name = General.LatestAddedForSale;
             else


### PR DESCRIPTION
The pagination logic in the `GetPropertiesBySaleType` method in `HomeController.cs` was flawed. The number of records to skip was calculated incorrectly, causing the method to return the wrong page of results.

This commit corrects the pagination calculation to `(pageNumber - 1) * PageSize` and removes a redundant and unreachable code block.

A new test case has been added to `HomeControllerTest.cs` to verify that the pagination now works as expected.